### PR TITLE
Fix clipping of FST waveforms from Verilator simulation

### DIFF
--- a/fstapi/csrc/fstapi.c
+++ b/fstapi/csrc/fstapi.c
@@ -2937,7 +2937,7 @@ if(FST_LIKELY((xc) && (handle <= xc->maxhandle)))
         vm4ip = &(xc->valpos_mem[4*handle]);
 
         len  = vm4ip[1];
-        if(FST_LIKELY(len && (uint32_t)len == vlen)) /* len of zero = variable length, use fstWriterEmitVariableLengthValueChange */
+        if(FST_LIKELY(len && vlen)) /* len of zero = variable length, use fstWriterEmitVariableLengthValueChange */
                 {
                 if(FST_LIKELY(!xc->is_initial_time))
                         {


### PR DESCRIPTION
When using `clipfst` on FST waveform received from Verilator simulation, program fails with message `Failed to write value change!`.

This PR is a fix proposition for this error.

Example waveform: [trace.zip](https://github.com/user-attachments/files/16443174/trace.zip)

Example command:
```bash
$ clipfst -e 70215500 trace.fst clipped_trace.fst
Failed to write value change!
```

